### PR TITLE
Fix serialization of strings with non-ascii characters

### DIFF
--- a/src/BinaryPack/Serialization/Processors/StringProcessor.cs
+++ b/src/BinaryPack/Serialization/Processors/StringProcessor.cs
@@ -66,11 +66,12 @@ namespace BinaryPack.Serialization.Processors
             il.EmitCallvirt(typeof(ArrayPool<byte>).GetMethod(nameof(ArrayPool<byte>.Rent)));
             il.EmitStoreLocal(Locals.Write.ByteArray);
 
-            // _ = Encoding.UTF8.GetBytes(obj, 0, length, array, 0);
+            // _ = Encoding.UTF8.GetBytes(obj, 0, obj.Length, array, 0);
             il.EmitReadMember(typeof(Encoding).GetProperty(nameof(Encoding.UTF8)));
             il.EmitLoadArgument(Arguments.Write.T);
-            il.EmitLoadInt32(0);
-            il.EmitLoadLocal(Locals.Write.Length);
+            il.EmitLoadInt32(0);            
+            il.EmitLoadArgument(Arguments.Write.T);
+            il.EmitReadMember(typeof(string).GetProperty(nameof(string.Length)));
             il.EmitLoadLocal(Locals.Write.ByteArray);
             il.EmitLoadInt32(0);
             il.EmitCallvirt(typeof(Encoding).GetMethod(nameof(Encoding.GetBytes), new[] { typeof(string), typeof(int), typeof(int), typeof(byte[]), typeof(int) }));

--- a/unit/BinaryPack.Unit.Internals/StringTest.cs
+++ b/unit/BinaryPack.Unit.Internals/StringTest.cs
@@ -24,6 +24,9 @@ namespace BinaryPack.Unit.Internals
         public void LongString() => Test("P!pl<C'a /2-2!N2r}N-N'[\\Ew'aoo.=grDr3oHG\")>;eZ <u yqGeyID2GCC=p/!sE>[Z'#S'+Fg?wivbiot:u!wxM H&#c7/:o5a_: v=?XSb#8[JaR 9e{CEb-'YN#F/V&(R6!Nn{{TGD7JfjXA06tTrq:}-!;m<2E*}1*4_#1;hGz!Ib7osa6vaN4ay\"Bm_.84'-LTaEa,&WlJt8RIiKwYzLHMzG8[aBYX.g\"<5a.N *q)bhjbNv$34[7Pd'W8-$Jb{2<.664(=IYpX>j2[T-h=GDONOV6(sBy]0+OKZJ8c{tj\"FuD3FZUuaCTlk");
 
         [TestMethod]
+        public void Utf8String() => Test("Ћирилица");
+
+        [TestMethod]
         [DataRow(1024 * 1024)]
         [DataRow(2048 * 1024)]
         [DataRow(4096L * 1024)]


### PR DESCRIPTION
Fixes #27. This was a fun exercise. `GetBytes` requires `charCount` and `byteCount` was provided.
No previous experience with IL, so it was like tapping in the dark. Great work!